### PR TITLE
feat(smart-report): implement responsive table with card view toggle

### DIFF
--- a/src/components/smart_report_mrt/smart_report_mrt.css
+++ b/src/components/smart_report_mrt/smart_report_mrt.css
@@ -1,0 +1,136 @@
+/* --- Responsive Table CSS --- */
+
+.responsive-card-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+/* Default Table Cell Padding (Example) */
+.responsive-card-table th,
+.responsive-card-table td {
+    padding: 8px 12px; /* Adjust to match default MRT/MUI padding */
+    text-align: left;
+    border-bottom: 1px solid #ddd; /* Default row separator */
+}
+ .responsive-card-table th {
+     font-weight: bold;
+ }
+ /* Remove bottom border from last row */
+  .responsive-card-table tr:last-child td {
+      border-bottom: none;
+  }
+
+
+/* --- Mobile Card View (Default Responsive) --- */
+/* @media screen and (max-width: 767px) { */
+
+  /* Hide header by default in mobile */
+  .responsive-card-table:not(.force-table-view) thead {
+    display: none;
+  }
+
+  /* Apply card styles only when NOT forced into table view */
+  .responsive-card-table:not(.force-table-view) {
+    border: none;
+    box-shadow: none;
+  }
+
+  .responsive-card-table:not(.force-table-view) tbody,
+  .responsive-card-table:not(.force-table-view) tr,
+  .responsive-card-table:not(.force-table-view) td {
+    display: block;
+    width: 100% !important;
+    box-sizing: border-box;
+  }
+
+  .responsive-card-table:not(.force-table-view) tr {
+    margin-bottom: 1.5rem;
+    border: 1px solid #ddd;
+    border-radius: 5px;
+    overflow: hidden;
+    box-shadow: 0 2px 5px rgba(0,0,0,0.1);
+    background-color: #fff;
+  }
+
+   .responsive-card-table:not(.force-table-view) tr.MuiTableRow-root {
+     background-color: transparent;
+  }
+
+
+  .responsive-card-table:not(.force-table-view) td {
+    text-align: right;
+    padding-left: 50%;
+    padding-top: 10px;
+    padding-bottom: 10px;
+    position: relative;
+    border: none;
+    border-bottom: 1px solid #eee;
+    min-height: 30px;
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+  }
+
+  .responsive-card-table:not(.force-table-view) tr td:last-child {
+    border-bottom: none;
+  }
+
+  .responsive-card-table:not(.force-table-view) td::before {
+    content: attr(data-label);
+    position: absolute;
+    left: 10px;
+    top: 50%;
+    transform: translateY(-50%);
+    width: calc(50% - 20px);
+    padding-right: 10px;
+    font-weight: bold;
+    text-align: left;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    color: #555;
+  }
+
+   /* --- Overrides when .force-table-view is active on mobile --- */
+
+  /* IMPORTANT: Show header when table view is forced */
+  .responsive-card-table.force-table-view thead {
+      display: table-header-group !important; /* Or initial */
+  }
+
+  /* Reset row display */
+  .responsive-card-table.force-table-view tr {
+      display: table-row !important;
+      /* Reset card styles */
+      margin-bottom: 0 !important;
+      border: none !important;
+      border-radius: 0 !important;
+      box-shadow: none !important;
+      background-color: transparent !important;
+      overflow: visible !important;
+  }
+
+  /* Reset cell display and styles */
+  .responsive-card-table.force-table-view td {
+      display: table-cell !important;
+      width: auto !important; /* Allow table layout */
+      /* Reset card cell styles */
+      text-align: left !important; /* Default alignment */
+      padding: 8px 12px !important; /* Restore original padding */
+      position: static !important;
+      border: none !important; /* Remove card border */
+      border-bottom: 1px solid #ddd !important; /* Restore row border */
+      min-height: auto !important;
+  }
+
+  /* Hide the generated labels when table view is forced */
+  .responsive-card-table.force-table-view td::before {
+      display: none !important;
+  }
+
+  /* Ensure last row border is correctly removed in forced table view */
+   .responsive-card-table.force-table-view tr:last-child td {
+       border-bottom: none !important;
+   }
+
+/* } */

--- a/src/components/smart_report_mrt/smart_report_mrt.tsx
+++ b/src/components/smart_report_mrt/smart_report_mrt.tsx
@@ -1,8 +1,45 @@
+import TableViewIcon from '@mui/icons-material/TableView';
+import ViewModuleIcon from '@mui/icons-material/ViewModule';
+import { Button } from "@mui/material";
 import { MaterialReactTable, MaterialReactTableProps, MRT_RowData } from "material-react-table";
+import { useState } from "react";
+import "./smart_report_mrt.css";
 
+/*
+  TODO: (Responsive Card View)
+  - Add a field `showInCardView` to the column definition. Default to false.
+  - Show columns that have `showInCardView` set to true in card view.
+  - When user toggles visibility of a column in card view, update the `showInCardView` field.
+*/
 export const SmartReportMRT = <T extends MRT_RowData>(props: MaterialReactTableProps<T>) => {
+  // State to control the view mode override. Default to table view on desktop & card view on mobile.
+  const [forceTableView, setForceTableView] = useState(window.innerWidth >= 500);
   return (
     <MaterialReactTable
+      // Add props to the main table element (<table>)
+      muiTableProps = {{
+        // Conditionally add the 'force-table-view' class
+        className: `responsive-card-table ${forceTableView ? 'force-table-view' : ''}`,
+        sx: {
+          maxWidth: forceTableView ? '100%' : '500px',
+        }
+      }}
+      // Add props to the table body cells (<td>)
+      // @ts-expect-error FIXME: Redeclare / Redfine / Extend `TableCellProps` to add `data-label` prop.
+      muiTableBodyCellProps = {({ cell }) => ({
+        'data-label': cell.column.columnDef.header,
+      })}
+      renderTopToolbar = {() => (
+        <div className="top-toolbar">
+          <Button 
+            onClick={() => setForceTableView(!forceTableView)}
+            startIcon={forceTableView ? <ViewModuleIcon /> : <TableViewIcon />}
+          >
+            {forceTableView ? 'Switch to Card View' : null}
+          </Button>
+        </div>
+      )}
+      
       {...props}
     />
   );


### PR DESCRIPTION
- Add responsive card view for mobile devices (<500px)
- Implement table/card view toggle button in toolbar
- Add CSS styles for responsive card layout with data labels
- Set default view based on screen width (table for desktop, card for mobile)
- Add TODO for future column visibility control in card view
- Fix table cell props with data-label for mobile view